### PR TITLE
🐛Fix: 공지사항을 삭제할 때 댓글이 삭제 되지 않던 점 (append cascade)

### DIFF
--- a/src/migrations/1676442844964-create_notice_comments_table.ts
+++ b/src/migrations/1676442844964-create_notice_comments_table.ts
@@ -9,7 +9,7 @@ export class createNoticeCommentsTable1676442844964 implements MigrationInterfac
     // TABLE
     await queryRunner.query(`CREATE TABLE IF NOT EXISTS notice_comments (
         id                  BIGINT      NOT NULL    DEFAULT nextval('notice_comments_id_seq') PRIMARY KEY,
-        notice_id           BIGINT      NOT NULL    REFERENCES notices(id),
+        notice_id           BIGINT      NOT NULL    REFERENCES notices(id) ON DELETE CASCADE,
         content             VARCHAR     NOT NULL,
     
         -- creator


### PR DESCRIPTION
## 작업 내용

- NoticeComment migration script 수정
  - Notice Comment가 Notice를 참조할 때 ON CASCADE DELETE 추가 